### PR TITLE
docs: add bootstrapping and LTO instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,3 +624,20 @@ sync-openpgp-key-refresh-retry-delay-mult = 4
 
 A new sync was done by running ```emerge --sync```.
 
+### GCC Optimization
+
+Now that a baseline copy of the GCC tests had been created, the gcc use flags were updated to updated to optimize the build
+and support graphite (isl). This was done by creating the file ```/etc/portage/package.use/gcc``` with the following line:
+
+```text
+>=sys-devel/gcc-13 graphite lto pgo zstd
+```
+
+The the systemd was updated using this command:
+
+```bash
+emerge -avuDU --with-bdeps=y @world
+```
+
+That build took quite a while because it needed to build GCC with both LTO and PGO.
+

--- a/README.md
+++ b/README.md
@@ -509,3 +509,28 @@ emerge -avuDU --with-bdeps=y --jobs=32 --load-average=20 @world
 emerge -av --depclean
 ```
 
+### ccache Setup
+
+ccache was installed using the following command:
+
+```bash
+emerge -av dev-util/ccache
+```
+
+The ```ccache``` feature was added to ```FEATURES``` in ```/etc/portage/make.conf```. The ```CCACHE_DIR``` variable
+was set to ```/var/cache/ccache``` in ```/etc/portage/make.conf``` as well.
+
+The ccache cache directory was configured using the following commands:
+
+```bash
+mkdir -p /mnt/chroot/var/cache/ccache
+chown -R portage:portage /mnt/chroot/var/cache/ccache
+cat <<EOF > /mnt/chroot/var/cache/ccache/ccache.conf
+max_size = 64.0G
+umask = 002
+hash_dir = false
+compiler_check = %compiler% -dumpversion
+cache_dir_levels = 4
+EOF
+```
+

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ cp --dereference /etc/resolv.conf /mnt/chroot/etc/
 Bootstrapping the system consists of installing the portage tree, configuring portage, setting the profile, and
 updating the system, and the rebuilding everything twice to ensure all packages are built with the latest compiler.
 
-After the initial update is completed, the GentooLTO overlay will be used as a reference to enable LTO and other
+After the initial update is completed, the GentooLTO overlay will be used to enable LTO and other
 optimizations. Doing this before the bootstrap will minimize the number of world rebuilds needed.
 Package testing needs enabled to ensure there are no issues with the packages being built.
 
@@ -421,7 +421,7 @@ en_US.UTF-8 UTF-8
 
 Then ```locale-gen``` was run within the chroot to generate the locales.
 
-### Portage Tree
+### Initial Portage Tree
 
 Mirrors were selected using the following command:
 
@@ -444,7 +444,7 @@ emerge-webrsync
 emerge --sync
 ```
 
-### Portage Configuration
+### Initial Portage Configuration
 
 The ```/etc/portage/make.conf``` file was updated in the chroot to the following:
 
@@ -538,11 +538,24 @@ cache_dir_levels = 4
 EOF
 ```
 
-### Package Testing
+### Full Portage Setup
 
-The ```test``` feature was added to ```FEATURES``` in ```/etc/portage/make.conf```.
+Git was installed so the /etc/portage directory could cloned from jhatler/jhatler-etc-portage.
 
-Then, the following commands were run to enable testing for all packages:
+```bash
+emerge -av dev-vcs/git
+```
+
+The /etc/portage directory was cloned using the following commands:
+
+```bash
+rm -rf /etc/portage /var/db/repos/*
+git clone https://github.com/jhatler/jhatler-etc-portage /etc/portage
+emerge --sync # will take a while to clone everything
+cd /var/db/repos/lto-overlay
+git checkout workaroundCleanup # this branch is needed until the cleanup is complete
+```
+
 
 ```bash
 emerge -avuDU --with-bdeps=y --jobs=32 --load-average=20 @world

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ GCC_TESTS_NO_IGNORE_BASELINE=1 emerge -av1 sys-devel/gcc
 
 That also creates a baseline copy of the GCC tests to be compared against later.
 
-### Bootstrapping
+### Finalizing the Bootstrap
 
 The ```test``` feature is enabled in /etc/portage which means there will be many circular dependencies that need
 to be addressed as part of bootstrapping.
@@ -645,7 +645,7 @@ dispatch-conf
 
 Then dependencies should be cleaned up and another rebuild performed.
 
-```
+```bash
 emerge -av --depclean
 emerge -av --emptytree --with-bdeps=y --jobs=32 --load-average=20 @world
 ```
@@ -780,7 +780,7 @@ rd.luks.name=[UUID of /dev/nvme2n1p4]=cryptdata2
 
 Finally, the cmdline should be ended with the following settings to specify the root filesystem location and mount flags.
 
-```
+```text
 root=/dev/mapper/vg0-root0 rootflags=compress=zstd,discard=async,max_inline=0,space_cache=v2,ssd,commit=120,user_subvol_rm_allowed,subvol=@gentoo
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ rc-update add sshd default
 ## LUKS Performance testing
 
 LUKS vs. Direct disk access was tested using FIO. 4MiB blocks were used to test the sequential read/write performance
-and 4KiB blocks were used to test the random read/write performance. A single NVME disk was used for the tests. The 
+and 4KiB blocks were used to test the random read/write performance. A single NVME disk was used for the tests. The
 results are summarized below:
 
 | Test Type | Queues Enabled | Submit from Crypt CPUs | Jobs | Random IO | Read (MiB/s) | Write (MiB/s) |
@@ -592,9 +592,9 @@ This is needed by some packages to build.
 systemd-machine-id-setup
 ```
 
-```dev-libs/glib``` requires ```dev-util/desktop-file-utils``` to be installed to bypass an ebuild bug which doesn't properly disable the dependent tests. 
+```dev-libs/glib``` requires ```dev-util/desktop-file-utils``` to be installed to bypass an ebuild bug which doesn't properly disable the dependent tests.
 
-```app-accessibility/at-spi2-core``` requires ```app-editors/gedit``` to be installed for the tests to pass ([Gentoo Bug 678372](https://bugs.gentoo.org/678372)). 
+```app-accessibility/at-spi2-core``` requires ```app-editors/gedit``` to be installed for the tests to pass ([Gentoo Bug 678372](https://bugs.gentoo.org/678372)).
 
 ```dev-util/umockdev``` needs ```x11-apps/xinput``` and ```x11-drivers/xf86-input-synaptics``` for the tests to pass.
 
@@ -790,7 +790,7 @@ The complete string comprising of the above three sections needs to be on a sing
 ```text
 uefi="yes"
 add_dracutmodules+=" bash btrfs crypt dm lvm mdraid systemd rescue rootfs-block "
-kernel_cmdline="[COMBINDED CMDLINE]"  
+kernel_cmdline="[COMBINDED CMDLINE]"
 ```
 
 Now that dracut is configured, a UKI image can be created using the command below:

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ mount -t btrfs \
 
 ### Stage 3 Install
 
-The ```llvm | systemd | merged-usr``` stage3 tarball link was copied from here:
+The ```systemd | merged-usr``` stage3 tarball link was copied from here:
 [https://www.gentoo.org/downloads/](https://www.gentoo.org/downloads/)
 
 The stage3 tarball was downloaded and verified using the following commands:
@@ -348,21 +348,22 @@ wget ${STAGE3_URL}
 wget ${STAGE3_URL}.CONTENTS.gz
 wget ${STAGE3_URL}.DIGESTS
 wget ${STAGE3_URL}.sha256
+wget ${STAGE3_URL}.asc
 
-sha256sum --check stage3-amd64-llvm-systemd-mergedusr-*.tar.xz.sha256
+sha256sum --check stage3-amd64-systemd-mergedusr-*.tar.xz.sha256
 
-openssl dgst -r -sha512 stage3-amd64-llvm-systemd-mergedusr-*.tar.xz
-openssl dgst -r -sha512 stage3-amd64-llvm-systemd-mergedusr-*.tar.xz.CONTENTS.gz
-openssl dgst -r -blake2b512 stage3-amd64-llvm-systemd-mergedusr-*.tar.xz
-openssl dgst -r -blake2b512 stage3-amd64-llvm-systemd-mergedusr-*.tar.xz.CONTENTS.gz
+openssl dgst -r -sha512 stage3-amd64-systemd-mergedusr-*.tar.xz
+openssl dgst -r -sha512 stage3-amd64-systemd-mergedusr-*.tar.xz.CONTENTS.gz
+openssl dgst -r -blake2b512 stage3-amd64-systemd-mergedusr-*.tar.xz
+openssl dgst -r -blake2b512 stage3-amd64-systemd-mergedusr-*.tar.xz.CONTENTS.gz
 
 # compare above output to hashes in this file
-cat stage3-amd64-llvm-systemd-mergedusr-*.tar.xz.DIGESTS
+cat stage3-amd64-systemd-mergedusr-*.tar.xz.DIGESTS
 
 gpg --import /usr/share/openpgp-keys/gentoo-release.asc
-gpg --verify stage3-amd64-llvm-systemd-mergedusr-*.tar.xz.asc
-gpg --verify stage3-amd64-llvm-systemd-mergedusr-*.tar.xz.DIGESTS
-gpg --verify stage3-amd64-llvm-systemd-mergedusr-*.tar.xz.sha256
+gpg --verify stage3-amd64-systemd-mergedusr-*.tar.xz.asc
+gpg --verify stage3-amd64-systemd-mergedusr-*.tar.xz.DIGESTS
+gpg --verify stage3-amd64-systemd-mergedusr-*.tar.xz.sha256
 ```
 
 The stage3 tarball was extracted using the following command:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Goals:
 
-- [ ] ([#4](https://github.com/jhatler/gentoo-precision-7540/issues/4)) Gentoo installed
+- [X] ([#4](https://github.com/jhatler/gentoo-precision-7540/issues/4)) Gentoo installed
 - [X] ([#5](https://github.com/jhatler/gentoo-precision-7540/issues/5)) LUKS full disk encryption with performance tuning
 - [X] ([#6](https://github.com/jhatler/gentoo-precision-7540/issues/6)) BTRFS raid0 for rootfs
 - [X] ([#7](https://github.com/jhatler/gentoo-precision-7540/issues/7)) Striped LVM for VMs and other filesystems
 - [X] ([#8](https://github.com/jhatler/gentoo-precision-7540/issues/8)) Ability to reallocate space between BTRFS and LVM
 - [ ] ([#9](https://github.com/jhatler/gentoo-precision-7540/issues/9)) BTRFS snapshots for rollback integrated into emerge
-- [ ] ([#10](https://github.com/jhatler/gentoo-precision-7540/issues/10)) System optimized with LTO, Graphite, PGO, and CFLAGS
+- [X] ([#10](https://github.com/jhatler/gentoo-precision-7540/issues/10)) System optimized with LTO, Graphite, PGO, and CFLAGS
 - [ ] ([#11](https://github.com/jhatler/gentoo-precision-7540/issues/11)) systemd-boot configured with secure boot
 - [ ] ([#12](https://github.com/jhatler/gentoo-precision-7540/issues/12)) Nvidia GPU working with CUDA and vGPU support
 - [ ] ([#13](https://github.com/jhatler/gentoo-precision-7540/issues/13)) KVM configured with virt-manager and libvirt support

--- a/README.md
+++ b/README.md
@@ -534,3 +534,93 @@ cache_dir_levels = 4
 EOF
 ```
 
+### Package Testing
+
+The ```test``` feature was added to ```FEATURES``` in ```/etc/portage/make.conf```.
+
+Then, the following commands were run to enable testing for all packages:
+
+```bash
+emerge -avuDU --with-bdeps=y --jobs=32 --load-average=20 @world
+```
+
+Some use changes were needed to get everything to build. The above command was run after each change until
+no more errors were encountered. USE flag changes needed for testing were put in the
+```/etc/portage/package.use/testing``` file.
+
+The non-tivial issues encountered were:
+- app-shells/fish needs the usersandbox feature disabled for tests to pass.
+  - [Gentoo Bug 838187](https://bugs.gentoo.org/838187)
+- The betamax python package was [forked](https://github.com/jhatler/betamax) until the following issues are resolved. The fork was placed in a local repository called ```local```.
+  - [betamax#200](https://github.com/betamaxpy/betamax/issues/200)
+  - [betamax#203](https://github.com/betamaxpy/betamax/issues/203)
+  - [betamax#204](https://github.com/betamaxpy/betamax/issues/204)
+- The ```dev-python/uvloop``` package was copied to the ```local``` repository and the patch found in the below issue was added. The dependency on a pre-v3 version of ```cython``` was removed.
+  - [uvloop#586](https://github.com/MagicStack/uvloop/issues/586)
+- The ```dev-python/autocommand``` package needed patched with the below PR due to the below bug.
+  - [autocommand#31](https://github.com/Lucretiel/autocommand/pull/31)
+  - [Gentoo Bug 917754](https://bugs.gentoo.org/917754)
+- The ```dev-python/cython``` tests failed to pass due to a path traversal error. This was resolved with the patch prodived to the below Gentoo bug.
+  - [Gentoo Bug 912814](https://bugs.gentoo.org/912814)
+- The ```dev-python/inflect``` package had a failing test which was fixed with the patch from the below PR submitted upstream.
+  - [inflect#205](https://github.com/jaraco/inflect/pull/205)
+- The ```dev-python/pytest-mock``` package had failing tests fixed in the below commits which were added as patches to my portage.
+  - [pytest-mock#403](https://github.com/pytest-dev/pytest-mock/pull/403)
+  - [pytest-mock#404](https://github.com/pytest-dev/pytest-mock/pull/404)
+- The ```dev-python/send2trash``` package fails its tests due to bad cross-platform support. The package was copied to the ```local``` repository and a patch was added to add additional checks before importing the mac and windows support.
+- The ```dev-python/terminado``` package had a missing BDEPEND on ```dev-python/pytest-timeout``` needed for testing.
+- The ```dev-python/pytest-virtualenv``` test called ```test_installed_packages``` had to be disabled due to a deprecation warning not expected by the test.
+- The ```dev-python/Faker``` package was copied to the ```local``` repository so the ```test_ssn_without_age_range``` test could be disabled. This test fails due to a bug in the upstream package.
+  - [Faker#1956](https://github.com/joke2k/faker/issues/1956)
+- The ```dev-vcs/mercurial``` package has flaky tests under parallelism, so they were disabled.
+- The tests of the following packages failed in non-concerning ways so I disabled them until I had the energy/time to dig in further.
+  - ```sys-libs/glibc```
+  - ```dev-python/cryptography```
+  - ```dev-python/pypiserver```
+  - ```dev-python/pycurl```
+    - ```curl``` needs downgraded to 8.3.0
+- The tests of ```sys-devel/gcc``` can be idealistic and some failures seem to be commonplace, per the Gentoo Buzilla. A baseline of the test results was prepared using the below command.
+  - ```GCC_TESTS_NO_IGNORE_BASELINE=1 emerge -v1 sys-devel/gcc```
+- ```dev-python/html5lib``` needed the patch in the below PR to be applied for the tests to complete.
+  - [html5lib#570](https://github.com/html5lib/html5lib-python/pull/570/)
+- ```dev-libs/glib``` requires ```dev-util/desktop-file-utils``` to be installed to bypass an ebuild bug which doesn't properly disable the dependent tests.
+  - This command must be used to bypass the circular dependency ```FEATURES="-test" emerge -av dev-util/desktop-file-utils```
+  - ```systemd-machine-id-setup``` must be run before trying  the ```dev-libs/glib``` tests.
+- ```dev-python/Pillow``` needs the following commit applied as a patch for the tests to pass.
+  - [Pillow#7594](https://github.com/python-pillow/Pillow/pull/7594)
+- ```app-accessibility/at-spi2-core``` requires ```app-editors/gedit``` to be installed for the tests to pass.
+  - [Gentoo Bug 678372](https://bugs.gentoo.org/678372)
+- ```dev-util/umockdev``` needs ```x11-apps/xinput``` and ```x11-drivers/xf86-input-synaptics``` for the tests to pass.
+- The below patch from Debian was applied to ```net-libs/libsoup-2.74.3``` to resolve a testing failure recorded in the below bug.
+  - [skip-tls_interaction-test.patch](https://sources.debian.org/data/main/libs/libsoup2.4/2.74.3-2/debian/patches/skip-tls_interaction-test.patch)
+  - [libsoup#120](https://gitlab.gnome.org/GNOME/libsoup/-/issues/120)
+- The ```gnome-base/dconf``` packages is needed for the ```net-libs/uhttpmock``` tests to work.
+- A single test, listed below, was failing on ```dev-python/matplotlib```. It was disabled for now given that package had to disable many tests to work.
+  - ```tests/test_image.py::test_imshow_masked_interpolation[png]```
+
+Once the package testing was complete, the gentoo repository was updated to use git instead of rsync for syncing.
+
+The /var/db/repos/gentoo directory was deleted. Then the ```/etc/portage/repos.conf/gentoo.conf``` file was updated to the below:
+
+```text
+[DEFAULT]
+main-repo = gentoo
+
+[gentoo]
+location = /var/db/repos/gentoo
+sync-type = git
+sync-uri = https://github.com/gentoo/gentoo.git
+auto-sync = yes
+clone-depth = 0
+sync-depth = 0
+sync-openpgp-key-path = /usr/share/openpgp-keys/gentoo-release.asc
+sync-openpgp-keyserver = hkps://keys.gentoo.org
+sync-openpgp-key-refresh-retry-count = 40
+sync-openpgp-key-refresh-retry-overall-timeout = 1200
+sync-openpgp-key-refresh-retry-delay-exp-base = 2
+sync-openpgp-key-refresh-retry-delay-max = 60
+sync-openpgp-key-refresh-retry-delay-mult = 4
+```
+
+A new sync was done by running ```emerge --sync```.
+

--- a/README.md
+++ b/README.md
@@ -799,10 +799,31 @@ Now that dracut is configured, a UKI image can be created using the command belo
 emerge --config sys-kernel/gentoo-kernel-bin
 ```
 
+### Rebooting
+
+A shell was opened outside of the chroot and the following commands were run to unmount and close everything:
 
 ```bash
-emerge -avuDU --with-bdeps=y @world
+umount -R /mnt/chroot
+umount /mnt/btrfs/root
+umount /mnt/btrfs/data
+swapoff -a
+cryptsetup close /dev/mapper/cryptboot
+mdadm --stop /dev/md127
+cryptsetup close /dev/mapper/cryptswap0
+cryptsetup close /dev/mapper/cryptswap1
+cryptsetup close /dev/mapper/cryptswap2
+vgchange -an vg0
+cryptsetup close /dev/mapper/cryptdata0
+cryptsetup close /dev/mapper/cryptdata1
+cryptsetup close /dev/mapper/cryptdata2
 ```
 
-That build took quite a while because it needed to build GCC with both LTO and PGO.
+The system was rebooted using the following command:
 
+```bash
+reboot
+```
+
+Once the UKI image boots, you will be prompted for the LUKS passphrase. Keeping the same passphrase for each LUKS volume will
+allow for it to be entered once and used for all volumes.

--- a/README.md
+++ b/README.md
@@ -556,6 +556,18 @@ cd /var/db/repos/lto-overlay
 git checkout workaroundCleanup # this branch is needed until the cleanup is complete
 ```
 
+### GCC Optimization
+
+The cloned portage configuration enabled optimizations for GCC which need built before other packages can be optimized.
+
+This was done by running the below command:
+
+```bash
+GCC_TESTS_NO_IGNORE_BASELINE=1 emerge -av1 sys-devel/gcc
+```
+
+That also creates a baseline copy of the GCC tests to be compared against later.
+
 
 ```bash
 emerge -avuDU --with-bdeps=y --jobs=32 --load-average=20 @world


### PR DESCRIPTION
This is a large commit that completes the bootstrapping and LTO setup
instructions. It relies on the jhatler/jhatler-overlay and the
jhatler/jhatler-etc-portage repositories to simplify the setup process.

An overview of the changes are as follows:
- Add LUKS performance testing notes
- Convert ESP volumes to standalone partitions
- Move to GCC stage3 tarball
- Add complete bootstrapping instructions
- Add Bootloader and Dracut instructions
- Add system configuration instructions to allow sign in
- Add reboot instructions

Refs: #4, #5, #6, #7, #8, #10, #11
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>